### PR TITLE
Server: header length limit, smart send, header end timeout, cgi location

### DIFF
--- a/config_files/default.conf
+++ b/config_files/default.conf
@@ -38,13 +38,10 @@ server {
 		return 306 /tours;
 	}
 
-    location /cgi-bin {
-        root cgi-bin/;
-        allow_methods GET POST DELETE;
-        index time.py;
-		client_max_body_size 88;
-        cgi_path /bin/bash /usr/bin/python3;
-        cgi_ext .sh .py;
+    location /upload {
+		root cgi-bin/;
+		allow_methods GET POST DELETE;
+		cgi_path upload.py;
     }
 }
 

--- a/inc/Client.hpp
+++ b/inc/Client.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Client.hpp                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: plouda <plouda@student.42prague.com>       +#+  +:+       +#+        */
+/*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/14 19:17:59 by aulicna           #+#    #+#             */
-/*   Updated: 2024/06/24 17:23:06 by plouda           ###   ########.fr       */
+/*   Updated: 2024/06/28 17:11:36 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,7 @@
 # include "webserv.hpp"
 # include "ServerConfig.hpp"
 # include "HttpRequest.hpp"
+# include "ResponseException.hpp"
 
 class Client
 {
@@ -27,12 +28,14 @@ class Client
 
 		void	setClientSocket(int clientSocket);
 		void	updateTimeLastMessage(void);
+		void	updateTimeLastValidHeaderEnd(void);
 		void	updateReceivedData(uint8_t *recvBuf, ssize_t &bytesReceived);
 		void	setPortConnectedOn(unsigned short portConnectedOn);
 		void	setServerConfig(const ServerConfig &serverConfig);
 
 		int					getClientSocket(void) const;
 		time_t				getTimeLastMessage(void) const;
+		time_t				getTimeLastValidHeaderEnd(void) const;
 		const octets_t		&getReceivedData(void) const;
 		octets_t			getReceivedHeader(void) const;
 		unsigned short		getPortConnectedOn(void) const;
@@ -45,6 +48,7 @@ class Client
 		void		eraseRangeReceivedData(size_t start, size_t end);
 		void		clearReceivedHeader(void);
 		void		trimHeaderEmptyLines(void);
+		bool		hasValidHeaderEnd(void);
 		void		separateValidHeader(void);
 		
 		HttpRequest	request;
@@ -53,6 +57,7 @@ class Client
 	private:
 		int					_clientSocket;
 		time_t				_timeLastMessage;
+		time_t				_timeLastValidHeaderEnd;
 		octets_t			_receivedData;
 		octets_t			_receivedHeader;
 		unsigned short		_portConnectedOn;

--- a/inc/HttpResponse.hpp
+++ b/inc/HttpResponse.hpp
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/14 10:48:46 by plouda            #+#    #+#             */
-/*   Updated: 2024/06/28 10:30:56 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/06/28 15:22:09 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,9 +34,10 @@ class HttpResponse
 		stringmap_t		headerFields;
 		octets_t		responseBody;
 		octets_t		completeResponse;
-		octets_t		message;
 		bool			statusLocked;
 		std::map<unsigned short,std::string>	codeDict;
+		octets_t		message;
+		bool			messageTooLongForOneSend;
 
 		void				readRequestedFile(const std::string& targetResource);
 		void				readErrorPage(const Location &location);
@@ -64,6 +65,8 @@ class HttpResponse
 		const octets_t&			getMessage() const;
 		void					setMessage(const octets_t& message);
 		void					eraseRangeMessage(size_t start, size_t end);
+		bool					getMessageTooLongForOneSend() const;
+		void					setMessageTooLongForOneSend(bool value);
 };
 
 #endif  // HTTPRESPONSE_HPP

--- a/inc/HttpResponse.hpp
+++ b/inc/HttpResponse.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   HttpResponse.hpp                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: plouda <plouda@student.42prague.com>       +#+  +:+       +#+        */
+/*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/14 10:48:46 by plouda            #+#    #+#             */
-/*   Updated: 2024/06/24 14:38:13 by plouda           ###   ########.fr       */
+/*   Updated: 2024/06/28 10:30:56 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,6 +34,7 @@ class HttpResponse
 		stringmap_t		headerFields;
 		octets_t		responseBody;
 		octets_t		completeResponse;
+		octets_t		message;
 		bool			statusLocked;
 		std::map<unsigned short,std::string>	codeDict;
 
@@ -55,11 +56,14 @@ class HttpResponse
 		void				setStatusLineAndDetails(const statusLine_t& statusLine, const std::string& details);
 		void				lockStatusCode();
 
-		const statusLine_t&	getStatusLine()	const;
+		const statusLine_t&		getStatusLine()	const;
 		const unsigned short&	getStatusCode() const;
 		const bool&				getStatusLocked() const;
 		void					setStatusCode(unsigned short code);
 		void					updateStatus(unsigned short code, const char* details);
+		const octets_t&			getMessage() const;
+		void					setMessage(const octets_t& message);
+		void					eraseRangeMessage(size_t start, size_t end);
 };
 
 #endif  // HTTPRESPONSE_HPP

--- a/inc/Location.hpp
+++ b/inc/Location.hpp
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/31 17:11:27 by aulicna           #+#    #+#             */
-/*   Updated: 2024/06/24 10:34:56 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/07/01 17:01:13 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,9 +31,8 @@ class Location
 		int											getRequestBodySizeLimit(void) const;
 		int											getAutoindex(void) const;
 		const std::set<std::string>					&getAllowMethods(void) const;
-		const std::vector<std::string>				&getCgiPath(void) const;
-		const std::vector<std::string>				&getCgiExt(void) const;
-		const std::map<std::string, std::string>	&getCgiMap(void) const;
+		const std::string							&getCgiPath(void) const;
+		const std::string							&getRelativeCgiPath(void) const;
 		const std::string							&getReturnURLOrBody(void) const;
 		unsigned short								getReturnCode(void) const;
 		bool										getIsRedirect(void) const;
@@ -44,8 +43,8 @@ class Location
 		void	setIndex(const std::vector<std::string> &index);
 		void	setRequestBodySizeLimit(int requestBodySizeLimit);
 		void	setAutoindex(int autoindex);
-		void	setCgiMap(std::map<std::string, std::string> &cgiMap);
 		void	setAllowMethods(const std::set<std::string> &allowMethods);
+		void	setRelativeCgiPath(const std::string &relativeCgiPath);
 		void	setReturnURLOrBody(const std::string &returnURLOrBody);
 		void	setReturnCode(unsigned short returnCode);
 		void	setIsRedirect(bool value);
@@ -62,9 +61,8 @@ class Location
 		int										_requestBodySizeLimit;
 		int										_autoindex;
 		std::set<std::string>					_allowMethods;
-		std::vector<std::string>				_cgiPath;
-		std::vector<std::string>				_cgiExt;
-		std::map<std::string, std::string>		_cgiMap;
+		std::string								_cgiPath;
+		std::string								_relativeCgiPath;
 		std::string								_returnURLOrBody;
 		unsigned short							_returnCode;
 		bool									_isRedirect;

--- a/inc/webserv.hpp
+++ b/inc/webserv.hpp
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/10 12:02:35 by aulicna           #+#    #+#             */
-/*   Updated: 2024/06/28 16:26:40 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/06/28 17:18:52 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,7 +53,8 @@ typedef std::map<std::string,std::string> stringmap_t;
 octets_t	convertStringToOctets(std::string str);
 
 # define PORT_SERVER 8000
-# define CONNECTION_TIMEOUT 5
+# define CONNECTION_TIMEOUT 20
+# define VALID_HEADER_TIMEOUT 30
 //# define CLIENT_MESSAGE_BUFF 4096 // 4 KB
 # define CLIENT_MESSAGE_BUFF 8196 // 8 KB
 //# define CLIENT_MESSAGE_BUFF 65536 // 64 KB
@@ -74,7 +75,6 @@ std::vector<std::string>	extractVectorUntilSemicolon(const std::vector<std::stri
 void						fileIsValidAndAccessible(const std::string &path, const std::string &exceptionMessage);
 std::string					dirIsValidAndAccessible(const std::string &path, const std::string &accessMessage, const std::string &dirOrFileMessage);
 std::string					resolveDotSegments(std::string path, DotSegmentsResolution flag);
-bool						hasValidHeaderEnd(const octets_t &receivedData);
 void						logSockets(int socket, std::string action);
 
 /* inline std::ostream &operator << (std::ostream &o, std::vector<std::string> &stringVectorToPrint)

--- a/inc/webserv.hpp
+++ b/inc/webserv.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   webserv.hpp                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: plouda <plouda@student.42prague.com>       +#+  +:+       +#+        */
+/*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/10 12:02:35 by aulicna           #+#    #+#             */
-/*   Updated: 2024/06/27 11:42:52 by plouda           ###   ########.fr       */
+/*   Updated: 2024/06/28 16:26:40 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,6 +34,10 @@
 # include <sstream>
 # include <arpa/inet.h>
 # include <limits.h>
+
+#ifndef DEBUG
+# define DEBUG 0
+#endif
 
 extern bool g_runWebserv;
 

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -6,13 +6,15 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/15 11:11:16 by aulicna           #+#    #+#             */
-/*   Updated: 2024/06/28 10:29:25 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/06/28 17:13:57 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../inc/Client.hpp"
 
-Client::Client(void):bufferUnchecked(false), _clientSocket(-1), _timeLastMessage(time(NULL)), _receivedData(), _receivedHeader(), _portConnectedOn(0)
+Client::Client(void): bufferUnchecked(false), _clientSocket(-1), 
+	_timeLastMessage(time(NULL)), _timeLastValidHeaderEnd(time(NULL)),
+	_receivedData(), _receivedHeader(), _portConnectedOn(0)
 {
 	return ;
 }
@@ -21,6 +23,7 @@ Client::Client(const Client& copy)
 {
 	this->_clientSocket = copy._clientSocket;
 	this->_timeLastMessage = copy._timeLastMessage;
+	this->_timeLastValidHeaderEnd = copy._timeLastValidHeaderEnd;
 	this->_receivedData = copy._receivedData;
 	this->_receivedHeader = copy._receivedHeader;
 	this->_portConnectedOn = copy._portConnectedOn;
@@ -35,6 +38,7 @@ Client	&Client::operator = (const Client &src)
 	{
 		this->_clientSocket = src._clientSocket;
 		this->_timeLastMessage = src._timeLastMessage;
+		this->_timeLastValidHeaderEnd = src._timeLastValidHeaderEnd;
 		this->_receivedData = src._receivedData;
 		this->_receivedHeader = src._receivedHeader;
 		this->_portConnectedOn = src._portConnectedOn;
@@ -60,6 +64,11 @@ void	Client::updateTimeLastMessage(void)
 	this->_timeLastMessage = time(NULL);
 }
 
+void	Client::updateTimeLastValidHeaderEnd(void)
+{
+	this->_timeLastValidHeaderEnd = time(NULL);
+}
+
 void	Client::updateReceivedData(uint8_t *recvBuf, ssize_t &bytesReceived)
 {
 	this->_receivedData.insert(this->_receivedData.end(), recvBuf, recvBuf + bytesReceived);
@@ -83,6 +92,11 @@ int	Client::getClientSocket(void) const
 time_t	Client::getTimeLastMessage(void) const
 {
 	return (this->_timeLastMessage);
+}
+
+time_t	Client::getTimeLastValidHeaderEnd(void) const
+{
+	return (this->_timeLastValidHeaderEnd);
 }
 
 const octets_t	&Client::getReceivedData(void) const
@@ -151,6 +165,26 @@ void	Client::trimHeaderEmptyLines(void)
 		nl = std::find(this->_receivedData.begin(), this->_receivedData.end(), '\n');
 		line = octets_t(this->_receivedData.begin(), nl);
 	}
+}
+
+bool Client::hasValidHeaderEnd(void)
+{
+	std::string sequences[] = {"\r\n\n", "\n\n", "\n\r\n", "\r\n\r\n"};
+	std::vector<unsigned char>::const_iterator endOfSequence;
+
+	for (int i = 0; i < 4; ++i)
+	{
+		endOfSequence = std::search(this->_receivedData.begin(), this->_receivedData.end(), sequences[i].begin(), sequences[i].end());
+		if (endOfSequence != this->_receivedData.end())
+		{
+			this->updateTimeLastValidHeaderEnd();
+			return (true);
+		}
+	}
+	std::cout << "NO HEADER" << std::endl;
+	if (this->_receivedData.size() > CLIENT_MESSAGE_BUFF * 2)
+		throw(ResponseException(413, "Request header too large"));
+	return (false);
 }
 
 void Client::separateValidHeader(void)

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Client.cpp                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: plouda <plouda@student.42prague.com>       +#+  +:+       +#+        */
+/*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/15 11:11:16 by aulicna           #+#    #+#             */
-/*   Updated: 2024/06/24 17:39:40 by plouda           ###   ########.fr       */
+/*   Updated: 2024/06/28 10:29:25 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -132,9 +132,7 @@ void	Client::eraseRangeReceivedData(size_t start, size_t end)
 {
 	//std::cout << "RECEIVED DATA " << this->_receivedData.size() << std::endl;
 	if (start <= end && end <= this->_receivedData.size())
-	{
 		this->_receivedData.erase(this->_receivedData.begin() + start, this->_receivedData.begin() + end);
-	}
 }
 
 void	Client::clearReceivedHeader(void)

--- a/src/HttpResponse.cpp
+++ b/src/HttpResponse.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   HttpResponse.cpp                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: plouda <plouda@student.42prague.com>       +#+  +:+       +#+        */
+/*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/14 10:52:29 by plouda            #+#    #+#             */
-/*   Updated: 2024/06/27 13:37:41 by plouda           ###   ########.fr       */
+/*   Updated: 2024/06/28 10:30:43 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,6 +67,7 @@ HttpResponse::HttpResponse()
 	this->responseBody = octets_t();
 	this->completeResponse = octets_t();
 	this->statusLocked = false;
+	this->message = octets_t();
 	return ;
 }
 
@@ -98,7 +99,8 @@ HttpResponse& HttpResponse::operator=(const HttpResponse& refObj)
 		responseBody = refObj.responseBody;
 		completeResponse = refObj.completeResponse;
 		codeDict = refObj.codeDict;
-		this->statusLocked = refObj.statusLocked;
+		statusLocked = refObj.statusLocked;
+		message = refObj.message;
 	}
 	return (*this);
 }
@@ -411,4 +413,21 @@ const octets_t		HttpResponse::prepareResponse(HttpRequest& request)
 const octets_t &HttpResponse::getCompleteResponse() const
 {
 	return (this->completeResponse);
+}
+
+const octets_t&	HttpResponse::getMessage() const
+{
+	return(this->message);
+
+}
+
+void	HttpResponse::setMessage(const octets_t& message)
+{
+	this->message = message;
+}
+
+void	HttpResponse::eraseRangeMessage(size_t start, size_t end)
+{
+	if (start <= end && end <= this->message.size())
+		this->message.erase(this->message.begin() + start, this->message.begin() + end);
 }

--- a/src/HttpResponse.cpp
+++ b/src/HttpResponse.cpp
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/14 10:52:29 by plouda            #+#    #+#             */
-/*   Updated: 2024/06/28 10:30:43 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/06/28 15:25:16 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -68,6 +68,7 @@ HttpResponse::HttpResponse()
 	this->completeResponse = octets_t();
 	this->statusLocked = false;
 	this->message = octets_t();
+	this->messageTooLongForOneSend = false;
 	return ;
 }
 
@@ -101,6 +102,7 @@ HttpResponse& HttpResponse::operator=(const HttpResponse& refObj)
 		codeDict = refObj.codeDict;
 		statusLocked = refObj.statusLocked;
 		message = refObj.message;
+		messageTooLongForOneSend = refObj.messageTooLongForOneSend;
 	}
 	return (*this);
 }
@@ -430,4 +432,14 @@ void	HttpResponse::eraseRangeMessage(size_t start, size_t end)
 {
 	if (start <= end && end <= this->message.size())
 		this->message.erase(this->message.begin() + start, this->message.begin() + end);
+}
+
+bool	HttpResponse::getMessageTooLongForOneSend() const
+{
+	return (this->messageTooLongForOneSend);
+}
+
+void	HttpResponse::setMessageTooLongForOneSend(bool value)
+{
+	this->messageTooLongForOneSend = value;
 }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/02 18:05:06 by aulicna           #+#    #+#             */
-/*   Updated: 2024/06/28 09:33:48 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/06/28 16:50:03 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -215,23 +215,6 @@ std::string	resolveDotSegments(std::string path, DotSegmentsResolution flag)
 		output.pop();
 	}
 	return (newPath);
-}
-
-bool hasValidHeaderEnd(const octets_t &receivedData)
-{
-	std::string sequences[] = {"\r\n\n", "\n\n", "\n\r\n", "\r\n\r\n"};
-	std::vector<unsigned char>::const_iterator endOfSequence;
-
-	for (int i = 0; i < 4; ++i)
-	{
-		endOfSequence = std::search(receivedData.begin(), receivedData.end(), sequences[i].begin(), sequences[i].end());
-		if (endOfSequence != receivedData.end())
-			return (true);
-	}
-	std::cout << "NO HEADER" << std::endl;
-	if (receivedData.size() > CLIENT_MESSAGE_BUFF * 2)
-		throw(ResponseException(413, "Request header too large"));
-	return (false);
 }
 
 octets_t	convertStringToOctets(std::string str)

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Utils.cpp                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: plouda <plouda@student.42prague.com>       +#+  +:+       +#+        */
+/*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/02 18:05:06 by aulicna           #+#    #+#             */
-/*   Updated: 2024/06/27 11:43:06 by plouda           ###   ########.fr       */
+/*   Updated: 2024/06/28 09:33:48 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -229,6 +229,8 @@ bool hasValidHeaderEnd(const octets_t &receivedData)
 			return (true);
 	}
 	std::cout << "NO HEADER" << std::endl;
+	if (receivedData.size() > CLIENT_MESSAGE_BUFF * 2)
+		throw(ResponseException(413, "Request header too large"));
 	return (false);
 }
 


### PR DESCRIPTION
- Header length limit & infinite send protection
  - hasValidHeaderEnd checks for the buffer being longer than CLIENT_MESSAGE_BUFF * 2 (without finding the valid header end) and throws 413 if so 

- Send to send everything:
  - Send to send everything if not enough space in client socket:
    - send returns send bytes or -1, so:
      - if sent bytes < message size, erase sent bytes from the buffer and send the rest in the next go (keeping the socket in write)
      - on -1 close connection
  - Buff allocation:
    - only what's neccessary gets allocated
    - max. 8 KB, longer messages get split between multiple sends (logic of the 1st bullet point))
  - Send to send everythig if message longer than 8 KB buffer
    - erase sent bytes and send the rest in the next go (keeping the socket in write)

- Timeout for sending valid header end
  - checkForTimeout now checks 2 timestamps: _timeLastMessage, _timeLastValidHeaderEnd

- New structure of CGI location in server config
![image](https://github.com/loudapet/42webserv/assets/106449030/7f3bbbc0-3bb4-4e0d-b185-6ae7d60be2ea)


FYI @loudapet - first 3 bullet points are relevant for you too